### PR TITLE
[FIX] error upgrading connector_search_engine

### DIFF
--- a/connector_search_engine/models/se_backend.py
+++ b/connector_search_engine/models/se_backend.py
@@ -38,9 +38,10 @@ class SeBackend(models.Model):
         vals = []
         s = self.with_context(active_test=False)
         for model, descr in spec_backend_selection:
-            records = s.env[model].search([])
-            for record in records:
-                vals.append((model, record.id))
+            if model in s.env:
+                records = s.env[model].search([])
+                for record in records:
+                    vals.append((model, record.id))
         return vals
 
     @api.model


### PR DESCRIPTION
This is an attempt to fix an error when trying to upgrade connector_search_engine from the Odoo UI, when connector_algolia is installed.

This was revealed when running the upgrade with module_auto_update's upgrade_changed_checksum which does the same as an upgrade triggered from the UI.

This upgrade method is apparently slightly different from from an command-line `-u`.

Although I do not understand it completely yet, I this there really is a bug here, because this methods attempts to access a model from a dependent module (connector_algolia) when initalizing connector_search_engine.

@Cedric-Pigeon this is the cause of the problem you had this morning.

cc/ @sebastienbeau @lmignon 

