### PR TITLE
[ADD] Search engine stock

### DIFF
--- a/connector_algolia/components/adapter.py
+++ b/connector_algolia/components/adapter.py
@@ -33,6 +33,16 @@ class AlgoliaAdapter(Component):
         index = self._get_index()
         index.add_objects(datas)
 
+    def update(self, datas):
+        """
+        Update the Algolia records based on given datas
+        :param datas: list of dict
+        :return: bool
+        """
+        index = self._get_index()
+        index.save_objects(datas)
+        return True
+
     def delete(self, binding_ids):
         index = self._get_index()
         index.delete_objects(binding_ids)

--- a/connector_search_engine/components/__init__.py
+++ b/connector_search_engine/components/__init__.py
@@ -7,3 +7,4 @@ from . import core
 from . import exporter
 from . import adapter
 from . import mapper
+from . import shopinvader_variant_json_export_mapper

--- a/connector_search_engine/components/adapter.py
+++ b/connector_search_engine/components/adapter.py
@@ -18,5 +18,13 @@ class SeAdapter(AbstractComponent):
     def add(self, datas):
         return NotImplemented
 
+    def update(self, datas):
+        """
+        Update given datas
+        :param datas: list of dict
+        :return: bool
+        """
+        return NotImplemented
+
     def delete(self, binding_ids):
         return NotImplemented

--- a/connector_search_engine/components/shopinvader_variant_json_export_mapper.py
+++ b/connector_search_engine/components/shopinvader_variant_json_export_mapper.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.addons.component.core import Component
+
+
+class ShopinvaderVariantJsonExportMapper(Component):
+    """
+    Define a default shopinvader.variant json export mapper
+    """
+    _name = 'shopinvader.variant.json.export.mapper'
+    _inherit = 'json.export.mapper'
+    _apply_on = ['shopinvader.variant']

--- a/connector_search_engine_algolia_stock/__init__.py
+++ b/connector_search_engine_algolia_stock/__init__.py
@@ -1,0 +1,1 @@
+from . import components

--- a/connector_search_engine_algolia_stock/__manifest__.py
+++ b/connector_search_engine_algolia_stock/__manifest__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Connector Search Engine Algolia stock",
+    "summary": "Shopinvader stock algolia",
+    "version": "10.0.1.0.0",
+    "category": "e-commerce",
+    "website": "https://akretion.com",
+    "author": "Akretion,ACSONE SA/NV",
+    "license": "AGPL-3",
+    "depends": [
+        'stock',
+        'shopinvader',
+        'connector_search_engine',
+        'connector_search_engine_stock',
+        'shopinvader_algolia',
+    ],
+    "data": [
+        'views/se_backend_algolia.xml',
+    ],
+}

--- a/connector_search_engine_algolia_stock/components/__init__.py
+++ b/connector_search_engine_algolia_stock/components/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import shopinvader_variant_json_export_mapper

--- a/connector_search_engine_algolia_stock/components/shopinvader_variant_json_export_mapper.py
+++ b/connector_search_engine_algolia_stock/components/shopinvader_variant_json_export_mapper.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.addons.component.core import Component
+
+
+class ShopinvaderVariantJsonExportMapper(Component):
+    """
+    Apply the export mapper to the Algolia search engine backend
+    """
+    _inherit = 'shopinvader.variant.json.export.mapper'
+    _collection = 'se.backend.algolia'

--- a/connector_search_engine_algolia_stock/tests/__init__.py
+++ b/connector_search_engine_algolia_stock/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import test_shopinvader_variant

--- a/connector_search_engine_algolia_stock/tests/test_shopinvader_variant.py
+++ b/connector_search_engine_algolia_stock/tests/test_shopinvader_variant.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from random import randint
+from odoo.addons.connector_algolia.tests.common import ConnectorAlgoliaCase
+
+
+class TestShopInvaderVariant(ConnectorAlgoliaCase):
+    """
+    Tests for shopinvader.variant
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestShopInvaderVariant, cls).setUpClass()
+        cls.shopinvader_backend = cls.env.ref('shopinvader.backend_1')
+        cls.shopinvader_backend.bind_all_product()
+
+    def setUp(self):
+        super(TestShopInvaderVariant, self).setUp()
+        self.index = self.env.ref('shopinvader_algolia.index_1')
+        self.template = self.env.ref(
+            'product.product_product_4_product_template')
+        self.shopinvader_variants = self.env['shopinvader.variant'].search([
+            ('record_id', 'in', self.template.product_variant_ids.ids),
+            ('backend_id', '=', self.backend.id),
+        ])
+        self.stock_field = self.env.ref(
+            "stock.field_product_product_qty_available")
+        self.wizard_stock_obj = self.env['stock.change.product.qty']
+
+    def _add_stock_to_product(self, product, qty=10):
+        """
+        Set the stock quantity of the product
+        :param product: product.product recordset
+        :param qty: float
+        :return: bool
+        """
+        wizard_obj = self.wizard_stock_obj
+        wizard = wizard_obj.create({
+            'product_id': product.id,
+            'new_quantity': qty,
+        })
+        wizard.change_product_qty()
+        return True
+
+    def test_export_json_stock1(self):
+        """
+        Test the export json created by the
+        shopinvader.variant.json.export.mapper.
+        This component should create a json who include the json saved
+        into the json_akeneo field by adding every key/value into the result.
+        For this case, we fill the json_akeneo field for every
+        shopinvader_variant and then we check 1 by 1 if the value is correct.
+        :return: bool
+        """
+        backend = self.backend
+        index = self.index
+        stock_field = self.stock_field
+        backend.write({
+            'product_stock_field_id': stock_field.id,
+            'export_stock_key': 'stock_value',
+        })
+        shopinvader_variants = self.shopinvader_variants
+        for product in shopinvader_variants.mapped("record_id"):
+            qty = randint(2, 1000)
+            self._add_stock_to_product(product, qty=qty)
+        field_name = backend.product_stock_field_id.name
+        stock_key = backend.export_stock_key
+        with backend.work_on('shopinvader.variant', index=index) as work:
+            mapper = work.component(usage='se.export.mapper')
+            for shopinvader_variant in shopinvader_variants:
+                stock_value = shopinvader_variant[field_name]
+                map_record = mapper.map_record(shopinvader_variant)
+                json_values = map_record.values()
+                self.assertIn(stock_key, json_values.keys())
+                self.assertEqual(stock_value, json_values.get(stock_key, 'a'))
+        return True
+
+    def test_export_json_stock2(self):
+        """
+        Test the export json created by the
+        shopinvader.variant.json.export.mapper.
+        This component should create a json who include the json saved
+        into the json_akeneo field by adding every key/value into the result.
+        For this case, we don't fill the export_stock_key to disable
+        the stock export. So we ensure that it's not exported
+        :return: bool
+        """
+        backend = self.backend
+        index = self.index
+        backend.write({
+            'product_stock_field_id': False,
+            'export_stock_key': False,
+        })
+        shopinvader_variants = self.shopinvader_variants
+        for product in shopinvader_variants.mapped("record_id"):
+            qty = randint(2, 1000)
+            self._add_stock_to_product(product, qty=qty)
+        with backend.work_on('shopinvader.variant', index=index) as work:
+            mapper = work.component(usage='se.export.mapper')
+            for shopinvader_variant in shopinvader_variants:
+                map_record = mapper.map_record(shopinvader_variant)
+                json_values = map_record.values()
+                self.assertNotIn('stock_value', json_values.keys())
+        return True

--- a/connector_search_engine_algolia_stock/views/se_backend_algolia.xml
+++ b/connector_search_engine_algolia_stock/views/se_backend_algolia.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="ir.ui.view" id="se_backend_algolia_form_view">
+        <field name="name">SE.backend.algolia.form (in connector_search_engine_algolia_stock)</field>
+        <field name="model">se.backend.algolia</field>
+        <field name="inherit_id" ref="connector_algolia.se_backend_algolia_form_view"/>
+        <field name="priority" eval="90"/>
+        <field name="arch" type="xml">
+            <group name="se-main" position="inside">
+                <field name="export_stock_key"/>
+                <field name="product_stock_field_id" attrs="{'required': [('export_stock_key', '!=', False)]}"/>
+            </group>
+        </field>
+    </record>
+
+</odoo>

--- a/connector_search_engine_stock/__init__.py
+++ b/connector_search_engine_stock/__init__.py
@@ -1,0 +1,2 @@
+from . import components
+from . import models

--- a/connector_search_engine_stock/__manifest__.py
+++ b/connector_search_engine_stock/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Connector Search Engine stock",
+    "summary": "Connector Search Engine stock",
+    "version": "10.0.1.0.0",
+    "category": "e-commerce",
+    "website": "https://akretion.com",
+    "author": "Akretion,ACSONE SA/NV",
+    "license": "AGPL-3",
+    'installable': True,
+    "depends": [
+        'stock',
+        'shopinvader',
+        'queue_job',
+        'connector_search_engine',
+        'shopinvader_search_engine',
+    ],
+    "data": [
+        'views/se_backend.xml',
+    ],
+}

--- a/connector_search_engine_stock/components/__init__.py
+++ b/connector_search_engine_stock/components/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import shopinvader_variant_json_export_mapper

--- a/connector_search_engine_stock/components/shopinvader_variant_json_export_mapper.py
+++ b/connector_search_engine_stock/components/shopinvader_variant_json_export_mapper.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.addons.component.core import Component
+
+
+class ShopinvaderVariantJsonStockExportMapper(Component):
+    _inherit = 'shopinvader.variant.json.export.mapper'
+
+    def _get_json_stock(self, shopinvader_variant):
+        """
+        Get the stock field value as a dict/json
+        :param shopinvader_variant: shopinvader.variant
+        :return: dict/json
+        """
+        values = {}
+        backend = self.backend_record
+        if backend.product_stock_field_id and backend.export_stock_key:
+            stock_key = backend.export_stock_key
+            values.update({
+                stock_key: shopinvader_variant._get_se_backend_stock_value(),
+            })
+        return values
+
+    def _apply(self, map_record, options=None):
+        """
+        Inherit the function to have json_akeneo values + shopinvader.variant
+        values into one dict/json
+        :param map_record: shopinvader.variant
+        :param options: dict
+        :return: dict/json
+        """
+        values = super(ShopinvaderVariantJsonStockExportMapper, self)._apply(
+            map_record=map_record, options=options)
+        values.update(self._get_json_stock(map_record.source))
+        return values

--- a/connector_search_engine_stock/models/__init__.py
+++ b/connector_search_engine_stock/models/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import se_backend
+from . import shopinvader_variant
+from . import stock_move

--- a/connector_search_engine_stock/models/se_backend.py
+++ b/connector_search_engine_stock/models/se_backend.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, exceptions, fields, models, _
+
+
+class SeBackend(models.Model):
+    _inherit = 'se.backend'
+
+    product_stock_field_id = fields.Many2one(
+        "ir.model.fields",
+        "Product stock field",
+        domain=[
+            ('ttype', 'in', ['float', 'integer']),
+            ('model_id.model', '=', 'product.product'),
+        ],
+        help="Field used to have the current stock of a product.product",
+    )
+    export_stock_key = fields.Char(
+        help="Key used into the export to contains the stock value defined by "
+             "the Product stock field.\n"
+             "This stock value export is disabled for the current backend if "
+             "this key is not set",
+    )
+
+    @api.multi
+    @api.constrains('export_stock_key', 'product_stock_field_id')
+    def _constraint_key_field_set(self):
+        """
+        Constraint to ensure that product_stock_field_id is set when the
+        export_stock_key field is filled.
+        :return:
+        """
+        bad_backends = self.filtered(
+            lambda b: b.export_stock_key and not b.product_stock_field_id)
+        bad_backends = bad_backends.with_prefetch(self._prefetch)
+        if bad_backends:
+            details = "\n- ".join(bad_backends.display_name)
+            message = _("Please set a stock field to fill the Export stock "
+                        "key for these backends:\n- %s") % details
+            raise exceptions.ValidationError(message)

--- a/connector_search_engine_stock/models/shopinvader_variant.py
+++ b/connector_search_engine_stock/models/shopinvader_variant.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, fields, models
+
+
+class ShopinvaderVariant(models.Model):
+    _inherit = 'shopinvader.variant'
+
+    # We should have a special field to save what is actually exported.
+    # But we don't have yet this information.
+    # We could maybe use the write_date of the odoo record (product.product in
+    # this case) but this write_date is not updated for computed fields.
+    # We can save all exported values into a special field but in which format?
+    # It's depend on the index, backend and the mapper (json,...) used.
+    # So for this usage only, we save the stock value into this field and we
+    # compare it to know if the update is useful or not.
+    last_stock_value = fields.Float(
+        help="Last stock value sent",
+        readonly=True,
+    )
+
+    @api.multi
+    def _get_se_backend_stock_value(self):
+        """
+        Get the stock value using the stock field defined on the se backend.
+        If a stock field is not defined on the backend, return 0
+        :return: float
+        """
+        self.ensure_one()
+        field = self.backend_id.se_backend_id.product_stock_field_id
+        stock_value = 0
+        if field:
+            stock_value = self[field.name]
+        return stock_value
+
+    @api.multi
+    def _update_stock_qty_sent(self, value):
+        """
+        Update the last quantity sent to related backend with the given value
+        :param value: float
+        :return: bool
+        """
+        return self.write({
+            'last_stock_value': value,
+        })

--- a/connector_search_engine_stock/models/stock_move.py
+++ b/connector_search_engine_stock/models/stock_move.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, exceptions, models, _
+from odoo.fields import first
+from odoo.addons.queue_job.job import job
+from odoo.tools import float_compare
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    @api.model
+    def _job_stock_can_start(self):
+        """
+        Check if the queue job can start (or should wait something)
+        :return: bool
+        """
+        return True
+
+    @api.model
+    def _get_stock_mapper(self):
+        """
+        Get the mapper to use.
+        Return None to have the default mapper
+        :return: str
+        """
+        return None
+
+    @api.multi
+    @job(default_channel='root.search_engine')
+    def _product_stock_update_all(self):
+        """
+        The goal of this function is to have shopinvader.variant grouped by
+        index.
+        This result will be given to another job (1 job/index). So in case
+        of failure, only the export of 1 index should be re-launched.
+        :return:
+        """
+        if not self._job_stock_can_start():
+            message = _("Another related queue job is running...")
+            raise exceptions.MissingError(message)
+        products = self.mapped("product_id")
+        shopinvader_variants = self._get_shopinvader_variants_from_product(
+            products)
+        mapper = self._get_stock_mapper()
+        all_backend = shopinvader_variants.mapped(
+            "se_backend_id")
+        all_index = all_backend.mapped("index_ids")
+        for index in all_index:
+            # Get shopinvader.variant of this index
+            variants_index = shopinvader_variants.filtered(
+                lambda s, i=index: s.index_id.id == i.id)
+            variants_index = variants_index.with_prefetch(self._prefetch)
+            description = "Update shopinvader variants (stock trigger) on " \
+                          "backend: %s index: %s" % \
+                          (index.backend_id.display_name, index.display_name)
+            if variants_index:
+                self.with_delay(
+                    description=description)._product_stock_update_by_index(
+                        variants_index, mapper)
+
+    @api.model
+    def _get_shopinvader_variants_from_product(self, products):
+        """
+        Extract shopinvader.variant from given product.product.
+        Get only variants of product binded and only if the stock value
+        has been updated since last sync
+        :param products: product.product recordset
+        :return: shopinvader.variant recordset
+        """
+        precision = self.env['decimal.precision'].precision_get(
+            'Product Unit of Measure')
+        products = products.filtered(
+            lambda p: p.is_shopinvader_binded).with_prefetch(self._prefetch)
+        # Get every shopinvader variant where the backend has a json key to
+        # export
+        shopinvader_variants = products.shopinvader_bind_ids.filtered(
+            lambda v: v.se_backend_id.export_stock_key)
+        shopinvader_variants = shopinvader_variants.with_prefetch(
+            self._prefetch)
+        # Get every shopinvader variant where the quantity has been updated
+        shopinvader_variants = shopinvader_variants.filtered(
+            lambda v:
+            float_compare(v._get_se_backend_stock_value(),
+                          v.last_stock_value, precision_digits=precision) != 0)
+        shopinvader_variants = shopinvader_variants.with_prefetch(
+            self._prefetch)
+        return shopinvader_variants
+
+    @api.multi
+    @job(default_channel='root.search_engine')
+    def _product_stock_update_by_index(self, shopinvader_variants, mapper):
+        """
+        Job to export shopinvader.variant by index
+        :param shopinvader_variants: shopinvader.variant recordset
+        :param mapper: str
+        :return:
+        """
+        index = shopinvader_variants.mapped("index_id")
+        # We should have only 1 index, not more, not less
+        if len(index) != 1:
+            message = _("Something wrong happens.\n"
+                        "We should have exactly 1 index to export!")
+            raise exceptions.MissingError(message)
+        backend = index.backend_id.specific_backend
+        model_name = first(shopinvader_variants)._name
+        with backend.work_on(model_name, index=index) as work:
+            exporter = work.component(usage='se.record.exporter')
+            # Update the quantity synchronized
+            for shopinvader_variant in shopinvader_variants:
+                stock_value = shopinvader_variant._get_se_backend_stock_value()
+                shopinvader_variant._update_stock_qty_sent(stock_value)
+            return exporter.run(shopinvader_variants, mapper=mapper)
+
+    @api.multi
+    def _jobify_product_stock_update(self):
+        """
+        Trigger on update on related backend if the product quantity has been
+        updated since last sync.
+        :return: bool
+        """
+        codes = ['incoming', 'outgoing']
+        moves = self.filtered(lambda m: m.picking_type_id.code in codes)
+        moves = moves.with_prefetch(self._prefetch)
+        if moves:
+            description = "Update shopinvader variants (stock update trigger)"
+            moves.with_delay(
+                description=description)._product_stock_update_all()
+        return True
+
+    @api.multi
+    def action_cancel(self):
+        """
+
+        :return: bool
+        """
+        result = super(StockMove, self).action_cancel()
+        self._jobify_product_stock_update()
+        return result
+
+    @api.multi
+    def action_confirm(self):
+        """
+
+        :return: stock.move recordset
+        """
+        result = super(StockMove, self).action_confirm()
+        self._jobify_product_stock_update()
+        return result
+
+    @api.multi
+    def action_done(self):
+        """
+
+        :return: bool
+        """
+        result = super(StockMove, self).action_done()
+        self._jobify_product_stock_update()
+        return result

--- a/connector_search_engine_stock/tests/__init__.py
+++ b/connector_search_engine_stock/tests/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import test_shopinvader_variant
+from . import test_stock_move

--- a/connector_search_engine_stock/tests/test_shopinvader_variant.py
+++ b/connector_search_engine_stock/tests/test_shopinvader_variant.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from uuid import uuid4
+from random import randint
+import mock
+from odoo import api, models
+from odoo.fields import first
+from odoo.addons.component.tests.common import SavepointComponentCase
+
+
+class TestSeBackend(models.Model):
+    _name = 'test.se.backend'
+    _inherit = 'se.backend.spec.abstract'
+    _description = 'Unit Test SE Backend'
+
+    def init(self):
+        self.env['se.backend'].register_spec_backend(self)
+
+    def _register_hook(self):
+        self.env['se.backend'].register_spec_backend(self)
+
+
+class TestShopinvaderVariant(SavepointComponentCase):
+    """
+    Tests for shopinvader.variant
+    """
+
+    def _init_test_model(self, model_cls):
+        """
+        Function to init/create a new Odoo Model during unit test.
+        Based on base_kanban_stage/test/test_base_kanban_abstract.py
+        :param model_cls: Odoo Model class
+        :return: instance of model (empty)
+        """
+        registry = self.env.registry
+        cr = self.env.cr
+        model_cls._build_model(registry, cr)
+        model = self.env[model_cls._name].with_context(todo=[])
+        model._prepare_setup()
+        model._setup_base(partial=False)
+        model._setup_fields(partial=False)
+        model._setup_complete()
+        model._auto_init()
+        model.init()
+        model._auto_end()
+        return self.env[model_cls._name]
+
+    def setUp(self):
+        super(TestShopinvaderVariant, self).setUp()
+        # To load a new Model, we have to use a new cursor and env.
+        # Because there is a commit on the model._auto_init()
+        # Based on base_kanban_stage/test/test_base_kanban_abstract.py
+        # self.registry.enter_test_mode()
+        # self.old_cursor = self.cr
+        # self.cr = self.registry.cursor()
+        self.cr.commit = mock.MagicMock()
+        self.env = api.Environment(self.cr, self.uid, {})
+        self.shopinvader_backend = self.env.ref('shopinvader.backend_1')
+        self.shopinvader_backend.bind_all_product()
+        test_se_backend_obj = self._init_test_model(TestSeBackend)
+        self.test_model = test_se_backend_obj
+        self.wizard_stock_obj = self.env['stock.change.product.qty']
+        self.test_se_backend_obj = test_se_backend_obj
+        # The target field is 'qty_available' on product.product
+        # This one is used into these tests.
+        # Please don't change it (or change it everywhere)
+        field_qty_available = self.env.ref(
+            "stock.field_product_product_qty_available")
+        backend_values = {
+            'product_stock_field_id': field_qty_available.id,
+            'export_stock_key': str(uuid4()),
+            'specific_model': test_se_backend_obj._name,
+        }
+        self.backend = backend = test_se_backend_obj.create(backend_values)
+        self.shopinvader_backend.write({
+            'se_backend_id': backend.se_backend_id.id,
+        })
+        self.product_tmpl = self.env.ref(
+            'product.product_product_4_product_template')
+
+    def _add_stock_to_product(self, product, qty=10):
+        """
+        Set the stock quantity of the product
+        :param product: product.product recordset
+        :param qty: float
+        :return: bool
+        """
+        wizard_obj = self.wizard_stock_obj
+        wizard = wizard_obj.create({
+            'product_id': product.id,
+            'new_quantity': qty,
+        })
+        wizard.change_product_qty()
+        return True
+
+    def test_get_se_backend_stock_value1(self):
+        """
+        Test the function _get_se_backend_stock_value() on shopinvader.variant.
+        This function should return the value based on the stock field set on
+        the related backend.
+        For example, if we set the 'qty_available' field on the backend,
+        the function should return the value of this field (applied on the
+        shopinvader.variant) so like if we
+        did shopinvader_variant.qty_available
+        :return: float
+        """
+        backend = self.backend
+        se_backend = backend.se_backend_id
+        product_tmpl = self.product_tmpl
+        shopinvader_variants = product_tmpl.product_variant_ids.mapped(
+            "shopinvader_bind_ids")
+        shopinvader_variants = shopinvader_variants.filtered(
+            lambda v: v.backend_id.se_backend_id.id == se_backend.id)
+        shopinvader_variant = first(shopinvader_variants)
+        product_product = shopinvader_variant.record_id
+        qty = randint(2, 1000)
+        self._add_stock_to_product(product_product, qty=qty)
+        # Ensure that the qty is updated
+        self.assertAlmostEqual(product_product.qty_available, qty)
+        dynamic_qty = shopinvader_variant._get_se_backend_stock_value()
+        self.assertAlmostEqual(dynamic_qty, qty)
+        # Re-update the quantity
+        qty = randint(2, 1000)
+        self._add_stock_to_product(product_product, qty=qty)
+        # Ensure that the qty is updated, again
+        self.assertAlmostEqual(product_product.qty_available, qty)
+        shopinvader_variant.refresh()
+        dynamic_qty = shopinvader_variant._get_se_backend_stock_value()
+        self.assertAlmostEqual(dynamic_qty, qty)
+        return True
+
+    def test_update_stock_qty_sent1(self):
+        """
+        Test the function _update_stock_qty_sent() on shopinvader.variant.
+        This function should update the field last_stock_value on
+        shopinvader.variant with the given quantity.
+        :return: float
+        """
+        backend = self.backend
+        se_backend = backend.se_backend_id
+        product_tmpl = self.product_tmpl
+        shopinvader_variants = product_tmpl.product_variant_ids.mapped(
+            "shopinvader_bind_ids")
+        shopinvader_variants = shopinvader_variants.filtered(
+            lambda v: v.backend_id.se_backend_id.id == se_backend.id)
+        shopinvader_variant = first(shopinvader_variants)
+        # Put an empty value
+        shopinvader_variant.write({
+            'last_stock_value': 0,
+        })
+        qty = randint(2, 1000)
+        shopinvader_variant._update_stock_qty_sent(qty)
+        self.assertAlmostEqual(shopinvader_variant.last_stock_value, qty)
+        qty = randint(2, 1000)
+        shopinvader_variant._update_stock_qty_sent(qty)
+        self.assertAlmostEqual(shopinvader_variant.last_stock_value, qty)
+        qty = randint(2, 1000)
+        shopinvader_variant._update_stock_qty_sent(qty)
+        self.assertAlmostEqual(shopinvader_variant.last_stock_value, qty)
+        return True

--- a/connector_search_engine_stock/tests/test_stock_move.py
+++ b/connector_search_engine_stock/tests/test_stock_move.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from uuid import uuid4
+from random import randint
+from contextlib import contextmanager
+import mock
+from odoo import api, models
+from odoo.addons.component.tests.common import SavepointComponentCase
+
+
+@contextmanager
+def mock_work_on(se_backend):
+    """
+    Replace the return value of the function 'work_on' by a lambda fct
+    :param se_backend: se.backend recordset
+    :return:
+    """
+    fct = 'work_on'
+    with mock.patch.object(se_backend.__class__, fct) as mocked_fct:
+        mocked_fct.return_value = mock.MagicMock()
+        yield
+
+
+class TestSeBackend(models.Model):
+    _name = 'test.se.backend'
+    _inherit = 'se.backend.spec.abstract'
+    _description = 'Unit Test SE Backend'
+
+    def init(self):
+        self.env['se.backend'].register_spec_backend(self)
+
+    def _register_hook(self):
+        self.env['se.backend'].register_spec_backend(self)
+
+
+class TestStockMove(SavepointComponentCase):
+    """
+    Tests for stock.move
+    """
+
+    def _init_test_model(self, model_cls):
+        """
+        Function to init/create a new Odoo Model during unit test.
+        Based on base_kanban_stage/test/test_base_kanban_abstract.py
+        :param model_cls: Odoo Model class
+        :return: instance of model (empty)
+        """
+        registry = self.env.registry
+        cr = self.env.cr
+        model_cls._build_model(registry, cr)
+        model = self.env[model_cls._name].with_context(todo=[])
+        model._prepare_setup()
+        model._setup_base(partial=False)
+        model._setup_fields(partial=False)
+        model._setup_complete()
+        model._auto_init()
+        model.init()
+        model._auto_end()
+        return self.env[model_cls._name]
+
+    def setUp(self):
+        super(TestStockMove, self).setUp()
+
+        self.cr.commit = mock.MagicMock()
+        self.env = api.Environment(self.cr, self.uid, {})
+        test_se_backend_obj = self._init_test_model(TestSeBackend)
+        self.test_se_backend_obj = test_se_backend_obj
+        self.wizard_stock_obj = self.env['stock.change.product.qty']
+        self.shopinvader_backend = self.env.ref('shopinvader.backend_1')
+        # se_backend_obj = self.env['se.backend']
+        field_qty_available = self.env.ref(
+            "stock.field_product_product_qty_available")
+        lang_en = self.env.ref("base.lang_en")
+        shopinvader_variant_model = self.env.ref(
+            "connector_search_engine_stock.model_shopinvader_variant")
+        index_values = {
+            'name': 'Index EN test',
+            'lang_id': lang_en.id,
+            'model_id': shopinvader_variant_model.id,
+        }
+        # For these tests, add the normal se.backend
+        # test_se_backend_obj.register_spec_backend(se_backend_obj)
+        backend_values = {
+            'product_stock_field_id': field_qty_available.id,
+            'export_stock_key': str(uuid4()),
+            'specific_model': test_se_backend_obj._name,
+            'index_ids': [
+                (0, False, index_values),
+            ]
+        }
+        self.backend = backend = test_se_backend_obj.create(backend_values)
+
+        self.shopinvader_backend.write({
+            'se_backend_id': backend.se_backend_id.id,
+        })
+
+        self.shopinvader_backend.bind_all_product()
+        self.move_obj = self.env['stock.move']
+        self.job_obj = self.env['queue.job']
+        self.loc_supplier = self.env.ref('stock.stock_location_suppliers')
+        self.product = self.env.ref('product.product_product_8')
+        self.picking_type_in = self.env.ref("stock.picking_type_in")
+
+    def _add_stock_to_product(self, product, qty=10):
+        """
+        Set the stock quantity of the product
+        :param product: product.product recordset
+        :param qty: float
+        :return: bool
+        """
+        wizard_obj = self.wizard_stock_obj
+        wizard = wizard_obj.create({
+            'product_id': product.id,
+            'new_quantity': qty,
+        })
+        wizard.change_product_qty()
+        return True
+
+    def test_action_cancel1(self):
+        """
+        Test the function action_cancel() on stock.move who should create a
+        new queue.job
+        :return:
+        """
+        move_obj = self.move_obj
+        job_obj = self.job_obj
+        picking_type_in = self.picking_type_in
+        loc_supplier = self.loc_supplier
+        product = self.product
+        values = {
+            'name': 'Forced Move',
+            'location_id': loc_supplier.id,
+            'location_dest_id': picking_type_in.default_location_dest_id.id,
+            'product_id': product.id,
+            'product_uom_qty': 2.0,
+            'product_uom': product.uom_id.id,
+            'picking_type_id': picking_type_in.id,
+        }
+        move = move_obj.create(values)
+        job_name = 'Update shopinvader variants (stock update trigger)'
+        domain_queue_job = [
+            ('name', 'ilike', job_name),
+        ]
+        nb_job_before = job_obj.search_count(domain_queue_job)
+        move.action_cancel()
+        nb_job_after = job_obj.search_count(domain_queue_job)
+        self.assertGreater(nb_job_after, nb_job_before)
+        return True
+
+    def test_action_confirm1(self):
+        """
+        Test the function action_confirm() on stock.move who should create a
+        new queue.job
+        :return:
+        """
+        move_obj = self.move_obj
+        job_obj = self.job_obj
+        picking_type_in = self.picking_type_in
+        loc_supplier = self.loc_supplier
+        product = self.product
+        values = {
+            'name': 'Forced Move',
+            'location_id': loc_supplier.id,
+            'location_dest_id': picking_type_in.default_location_dest_id.id,
+            'product_id': product.id,
+            'product_uom_qty': 2.0,
+            'product_uom': product.uom_id.id,
+            'picking_type_id': picking_type_in.id,
+        }
+        move = move_obj.create(values)
+        job_name = 'Update shopinvader variants (stock update trigger)'
+        domain_queue_job = [
+            ('name', 'ilike', job_name),
+        ]
+        nb_job_before = job_obj.search_count(domain_queue_job)
+        move.action_confirm()
+        nb_job_after = job_obj.search_count(domain_queue_job)
+        self.assertGreater(nb_job_after, nb_job_before)
+        return True
+
+    def test_action_done1(self):
+        """
+        Test the function action_done() on stock.move who should create a
+        new queue.job
+        :return:
+        """
+        move_obj = self.move_obj
+        job_obj = self.job_obj
+        picking_type_in = self.picking_type_in
+        loc_supplier = self.loc_supplier
+        product = self.product
+        values = {
+            'name': 'Forced Move',
+            'location_id': loc_supplier.id,
+            'location_dest_id': picking_type_in.default_location_dest_id.id,
+            'product_id': product.id,
+            'product_uom_qty': 2.0,
+            'product_uom': product.uom_id.id,
+            'picking_type_id': picking_type_in.id,
+        }
+        move = move_obj.create(values)
+        job_name = 'Update shopinvader variants (stock update trigger)'
+        domain_queue_job = [
+            ('name', 'ilike', job_name),
+        ]
+        nb_job_before = job_obj.search_count(domain_queue_job)
+        move.action_done()
+        nb_job_after = job_obj.search_count(domain_queue_job)
+        self.assertGreater(nb_job_after, nb_job_before)
+        return True
+
+    def test_product_stock_update_all1(self):
+        """
+        Test the function _product_stock_update_all() on stock.move who should
+        create 1 new queue.job per index (related to shopinvader.variant)
+        :return:
+        """
+        move_obj = self.move_obj
+        job_obj = self.job_obj
+        picking_type_in = self.picking_type_in
+        loc_supplier = self.loc_supplier
+        product = self.product
+        qty = randint(2, 1000)
+        self._add_stock_to_product(product, qty=qty)
+        values = {
+            'name': 'Forced Move',
+            'location_id': loc_supplier.id,
+            'location_dest_id': picking_type_in.default_location_dest_id.id,
+            'product_id': product.id,
+            'product_uom_qty': 2.0,
+            'product_uom': product.uom_id.id,
+            'picking_type_id': picking_type_in.id,
+        }
+        move = move_obj.create(values)
+        job_name = 'Update shopinvader variants (stock trigger) on backend'
+        domain_queue_job = [
+            ('name', 'ilike', job_name),
+        ]
+        nb_job_before = job_obj.search_count(domain_queue_job)
+        move._product_stock_update_all()
+        nb_job_after = job_obj.search_count(domain_queue_job)
+        self.assertGreater(nb_job_after, nb_job_before)
+        return True
+
+    def test_product_stock_update_by_index1(self):
+        """
+        Test the function _product_stock_update_by_index() on stock.move.
+        This one should run the export (not tested here) and also update
+        the last quantity synchronized
+        :return:
+        """
+        move_obj = self.move_obj
+        picking_type_in = self.picking_type_in
+        loc_supplier = self.loc_supplier
+        product = self.product
+        qty = randint(2, 1000)
+        self._add_stock_to_product(product, qty=qty)
+        shopinvader_variant = move_obj._get_shopinvader_variants_from_product(
+            product)
+        values = {
+            'name': 'Forced Move',
+            'location_id': loc_supplier.id,
+            'location_dest_id': picking_type_in.default_location_dest_id.id,
+            'product_id': product.id,
+            'product_uom_qty': 2.0,
+            'product_uom': product.uom_id.id,
+            'picking_type_id': picking_type_in.id,
+        }
+        move = move_obj.create(values)
+        mapper = move_obj._get_stock_mapper()
+        spec_backend = shopinvader_variant.index_id.backend_id.specific_backend
+        spec_backend.work_on = mock.MagicMock()
+        expected_value = shopinvader_variant._get_se_backend_stock_value()
+        with mock_work_on(spec_backend):
+            move._product_stock_update_by_index(shopinvader_variant, mapper)
+        self.assertAlmostEqual(
+            shopinvader_variant.last_stock_value, expected_value)
+        return True

--- a/connector_search_engine_stock/views/se_backend.xml
+++ b/connector_search_engine_stock/views/se_backend.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="ir.ui.view" id="se_backend_form_view">
+        <field name="name">SE.backend.form (in connector_search_engine_stock)</field>
+        <field name="model">se.backend</field>
+        <field name="inherit_id" ref="connector_search_engine.se_backend_form_view"/>
+        <field name="priority" eval="90"/>
+        <field name="arch" type="xml">
+            <group name="se-main" position="inside">
+                <field name="export_stock_key"/>
+                <field name="product_stock_field_id" attrs="{'required': [('export_stock_key', '!=', False)]}"/>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/setup/connector_search_engine_algolia_stock/odoo/__init__.py
+++ b/setup/connector_search_engine_algolia_stock/odoo/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/connector_search_engine_algolia_stock/odoo/addons/__init__.py
+++ b/setup/connector_search_engine_algolia_stock/odoo/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/connector_search_engine_algolia_stock/odoo/addons/connector_search_engine_algolia_stock
+++ b/setup/connector_search_engine_algolia_stock/odoo/addons/connector_search_engine_algolia_stock
@@ -1,0 +1,1 @@
+../../../../connector_search_engine_algolia_stock

--- a/setup/connector_search_engine_algolia_stock/setup.py
+++ b/setup/connector_search_engine_algolia_stock/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/connector_search_engine_stock/odoo/__init__.py
+++ b/setup/connector_search_engine_stock/odoo/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/connector_search_engine_stock/odoo/addons/__init__.py
+++ b/setup/connector_search_engine_stock/odoo/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/connector_search_engine_stock/odoo/addons/connector_search_engine_stock
+++ b/setup/connector_search_engine_stock/odoo/addons/connector_search_engine_stock
@@ -1,0 +1,1 @@
+../../../../connector_search_engine_stock

--- a/setup/connector_search_engine_stock/setup.py
+++ b/setup/connector_search_engine_stock/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This MR depends on the MR 24.
Still a strange behaviour into Unit test:
If you create a new Unit test (into connector_search_engine_stock module) file without using the the test.se.backend Model, you will have an error if you try to create a se.backend. Due to this test.se.backend model.
Odoo try to load it but this one is not into the registry and not into the Database... So Boom!
If someone can check and maybe fix what I miss, that'll be great!