### PR TITLE
[FIX] Fix bug after uninstalling a connector module

### DIFF
--- a/connector_search_engine/models/se_backend.py
+++ b/connector_search_engine/models/se_backend.py
@@ -38,7 +38,13 @@ class SeBackend(models.Model):
         vals = []
         s = self.with_context(active_test=False)
         for model, descr in spec_backend_selection:
-            if model in s.env:
+            # We have to check if the table really exist.
+            # Because in the case of the user uninstall a connector_XXX module
+            # with a new se.backend (so who adds a new element into selection
+            # field), no more se.backend will be available (because the
+            # selection field still filled with the previous model and Odoo
+            # try to load the model).
+            if model in s.env and s.env[model]._table_exist():
                 records = s.env[model].search([])
                 for record in records:
                     vals.append((model, record.id))


### PR DESCRIPTION
**How to reproduce:**
- Create a module with a new se.backend model (so the model must inherit 'se.backend.spec.abstract');
- Create a view to add your new se.backend that you just create;
- Create a new specific se.backend (using your new model);
- Go into the normal se.backend view (to display all of them, whatever the specificity of the backend);
- No error, you can see everything;
- Now uninstall your module (the one just created before);
- Refresh your browser (to ensure no removed data still here);
- Go to the normal se.backend view (as before);
- BOOM!
- You can restart the server, the issue still there =/

**Origin of the error:**
- Choices into selection field is not removed. And due to a computed field (specific_backend), the compute function try to load the previous model.

**How to fix:**
- Solution 1 (not the best but easier):
-- Check if the table exists in Database into the compute function;
- Solution 2:
-- Find a way to remove this value (from selection choices) during uninstall;
- Solution 3:
-- Stop using the register_spec_backend(...) function;
-- Use another way to save specific model (maye into another table,...)

Exemple of new se.backend:
```
class TitiSeBackend(models.Model):
    _name = 'titi.se.backend'
    _inherit = 'se.backend.spec.abstract'
    _description = 'Titi SE Backend'

    def init(self):
        self.env['se.backend'].register_spec_backend(self)

    def _register_hook(self):
        self.env['se.backend'].register_spec_backend(self)
```

