### PR TITLE
[REF] start to refactor the export, by splitting it in two step. 

### DIFF
--- a/connector_algolia/components/adapter.py
+++ b/connector_algolia/components/adapter.py
@@ -7,6 +7,8 @@
 import logging
 
 from odoo.addons.component.core import Component
+from odoo import _
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -29,8 +31,14 @@ class AlgoliaAdapter(Component):
             backend.algolia_app_id, account._get_password())
         return client.initIndex(self.work.index.name)
 
-    def add(self, datas):
+    def index(self, datas):
         index = self._get_index()
+        # Ensure that the objectID is set because algolia will use it
+        # for creating or updating the record
+        for data in datas:
+            if not data.get('objectID'):
+                raise UserError(
+                    _('The key objectID is missing in the data %s') % data)
         index.add_objects(datas)
 
     def delete(self, binding_ids):

--- a/connector_algolia/components/adapter.py
+++ b/connector_algolia/components/adapter.py
@@ -44,3 +44,7 @@ class AlgoliaAdapter(Component):
     def delete(self, binding_ids):
         index = self._get_index()
         index.delete_objects(binding_ids)
+
+    def clear(self):
+        index = self._get_index()
+        index.clear_index()

--- a/connector_algolia/tests/test_connector_algolia.py
+++ b/connector_algolia/tests/test_connector_algolia.py
@@ -4,15 +4,14 @@
 
 import mock
 from odoo import _
-from odoo.addons.queue_job.job import Job
-
+from odoo.addons.queue_job.tests.common import JobMixin
 
 from .common import ConnectorAlgoliaCase
 from .common import mock_api
 from .models import ResPartner
 
 
-class TestConnectorAlgolia(ConnectorAlgoliaCase):
+class TestConnectorAlgolia(ConnectorAlgoliaCase, JobMixin):
 
     def _init_test_model(self, model_cls):
         registry = self.env.registry
@@ -33,14 +32,14 @@ class TestConnectorAlgolia(ConnectorAlgoliaCase):
         ir_model_res_partner = self.env['ir.model'].search(
             [('model', '=', 'res.partner')])
         res_lang = self.env['res.lang'].search([], limit=1)
-        exporter_id = self.env.ref('base_jsonify.ir_exp_partner')
+        self.exporter = self.env.ref('base_jsonify.ir_exp_partner')
         self.se_index_model = self.env['se.index']
         self.se_index = self.se_index_model.create({
             'name': 'partner index',
             'backend_id': self.backend.se_backend_id.id,
             'model_id': ir_model_res_partner.id,
             'lang_id': res_lang.id,
-            'exporter_id': exporter_id.id
+            'exporter_id': self.exporter.id
         })
         # init our test model after the creation of the index since this one
         # will be used as default value
@@ -49,54 +48,57 @@ class TestConnectorAlgolia(ConnectorAlgoliaCase):
         self.cr.commit = mock.MagicMock()
         self._init_test_model(ResPartner)
 
-    def test_export_all_indexes(self):
+    def test_recompute_all_indexes(self):
+        partner = self.env.ref('base.main_partner')
+        self.assertEqual(partner.data, {})
 
-        with mock_api(self.env) as mocked_api:
-            self.assertFalse(self.se_index.name in mocked_api.index)
-            self.se_index_model.export_all_index(delay=False)
-            self.assertTrue(self.se_index.name in mocked_api.index)
-            index = mocked_api.index[self.se_index.name]
-            self.assertEqual(1, len(index._calls))
-            method, values = index._calls[0]
-            self.assertEqual('add_objects', method)
-            self.assertEqual(
-                self.env['res.partner'].search_count([]),
-                len(values)
-            )
+        jobs = self.job_counter()
+        self.se_index_model.recompute_all_index(
+            [('id', '=', self.se_index.id)])
+
+        # check that a job have been created for each binding
+        nbr_binding = self.env['res.partner'].search_count([])
+        self.assertEqual(jobs.count_created, nbr_binding)
+        self.perform_jobs(jobs)
+
+        # check that all binding have been recomputed and set to be updated
+        nbr_binding_to_update = self.env['res.partner'].search_count(
+            [('sync_state', '=', 'to_update')])
+        self.assertEqual(nbr_binding_to_update, nbr_binding)
+
+        # Check that the json data have been updated
+        parser = self.exporter.get_json_parser()
+        data = partner.jsonify(parser)[0]
+        data['id'] = partner.id  # the mapper add the id of the record
+        self.assertDictEqual(partner.data, data)
+
 
     def test_export_jobs(self):
-        queue_job_model = self.env['queue.job']
-        existing_jobs = queue_job_model.search([])
-        with mock_api(self.env) as mocked_api:
-            self.assertFalse(self.se_index.name in mocked_api.index)
-            self.se_index_model.export_all_index(delay=True)
-        # by default the export method create 2 jobs
-        # the first one to split the bindings to export into batch
-        # the second one to export each batch
-        new_jobs = queue_job_model.search([])
-        new_job = new_jobs - existing_jobs
-        self.assertEqual(1, len(new_job))
-        job = Job.load(self.env, new_job.uuid)
+        # Set partner to be updated with fake vals in data
+        partners = self.env['res.partner'].search([])
+        partners.write({'sync_state': 'to_update', 'data': {'foo': 'test'}})
+        count = len(partners)
+
+        # Generate Batch export job
+        jobs = self.job_counter()
+        self.se_index_model.generate_batch_export_per_index(
+            [('id', '=', self.se_index.id)])
+        self.assertEqual(jobs.count_created, 1)
         self.assertEqual(
             _('Prepare a batch export of indexes'),
-            job.description)
-        # at this stage the mocked_api is not yet called
-        self.assertFalse(self.se_index.name in mocked_api.index)
-        # perform the job
-        existing_jobs = new_jobs
-        job.perform()
-        new_jobs = queue_job_model.search([])
-        new_job = new_jobs - existing_jobs
-        self.assertEqual(1, len(new_job))
-        job = Job.load(self.env, new_job.uuid)
-        count = self.env['res.partner'].search_count([])
+            jobs.created.name)
+
+        # Run batch export and check that export job have been created
+        jobs2 = self.job_counter()
+        self.perform_jobs(jobs)
+        self.assertEqual(jobs2.count_created, 1)
         self.assertEqual(
             _("Export %d records of %d for index 'partner index'") % (
                 count, count),
-            job.description)
-        self.assertFalse(self.se_index.name in mocked_api.index)
-        # the last job is the one performing the export
-        job = Job.load(self.env, new_job.uuid)
+            jobs2.created.name)
+
+        # Run export job and check that algolia have been called
         with mock_api(self.env) as mocked_api:
-            job.perform()
-        self.assertTrue(self.se_index.name in mocked_api.index)
+            self.assertFalse(self.se_index.name in mocked_api.index)
+            self.perform_jobs(jobs2)
+            self.assertTrue(self.se_index.name in mocked_api.index)

--- a/connector_algolia/tests/test_connector_algolia.py
+++ b/connector_algolia/tests/test_connector_algolia.py
@@ -76,7 +76,10 @@ class TestConnectorAlgolia(ConnectorAlgoliaCase, JobMixin):
     def test_export_jobs(self):
         # Set partner to be updated with fake vals in data
         partners = self.env['res.partner'].search([])
-        partners.write({'sync_state': 'to_update', 'data': {'foo': 'test'}})
+        partners.write({
+            'sync_state': 'to_update',
+            'data': {'objectID': 'foo'},
+            })
         count = len(partners)
 
         # Generate Batch export job

--- a/connector_algolia/tests/test_connector_algolia.py
+++ b/connector_algolia/tests/test_connector_algolia.py
@@ -72,7 +72,6 @@ class TestConnectorAlgolia(ConnectorAlgoliaCase, JobMixin):
         data['id'] = partner.id  # the mapper add the id of the record
         self.assertDictEqual(partner.data, data)
 
-
     def test_export_jobs(self):
         # Set partner to be updated with fake vals in data
         partners = self.env['res.partner'].search([])
@@ -88,7 +87,7 @@ class TestConnectorAlgolia(ConnectorAlgoliaCase, JobMixin):
             [('id', '=', self.se_index.id)])
         self.assertEqual(jobs.count_created, 1)
         self.assertEqual(
-            _('Prepare a batch export of indexes'),
+            _("Prepare a batch export of index '%s'") % self.se_index.name,
             jobs.created.name)
 
         # Run batch export and check that export job have been created

--- a/connector_algolia/tests/test_connector_algolia.py
+++ b/connector_algolia/tests/test_connector_algolia.py
@@ -58,7 +58,7 @@ class TestConnectorAlgolia(ConnectorAlgoliaCase, JobMixin):
 
         # check that a job have been created for each binding
         nbr_binding = self.env['res.partner'].search_count([])
-        self.assertEqual(jobs.count_created, nbr_binding)
+        self.assertEqual(jobs.count_created(), nbr_binding)
         self.perform_jobs(jobs)
 
         # check that all binding have been recomputed and set to be updated
@@ -85,19 +85,19 @@ class TestConnectorAlgolia(ConnectorAlgoliaCase, JobMixin):
         jobs = self.job_counter()
         self.se_index_model.generate_batch_export_per_index(
             [('id', '=', self.se_index.id)])
-        self.assertEqual(jobs.count_created, 1)
+        self.assertEqual(jobs.count_created(), 1)
         self.assertEqual(
             _("Prepare a batch export of index '%s'") % self.se_index.name,
-            jobs.created.name)
+            jobs.search_created().name)
 
         # Run batch export and check that export job have been created
         jobs2 = self.job_counter()
         self.perform_jobs(jobs)
-        self.assertEqual(jobs2.count_created, 1)
+        self.assertEqual(jobs2.count_created(), 1)
         self.assertEqual(
             _("Export %d records of %d for index 'partner index'") % (
                 count, count),
-            jobs2.created.name)
+            jobs2.search_created().name)
 
         # Run export job and check that algolia have been called
         with mock_api(self.env) as mocked_api:

--- a/connector_algolia/views/se_backend_algolia.xml
+++ b/connector_algolia/views/se_backend_algolia.xml
@@ -23,7 +23,8 @@
                                 <field name="name"/>
                                 <field name="lang_id"/>
                                 <field name="model_id"/>
-                                <field name="exporter_id"/>
+                                <field name="exporter_id" context="{'form_view_ref': 'connector_algolia.view_ir_exports'}"/>
+                                <field name="batch_size"/>
                                 <button name="export_all"
                                         icon="fa-refresh"
                                         type="object"/>
@@ -34,6 +35,8 @@
             </form>
         </field>
     </record>
+
+
 
     <record model="ir.ui.view" id="se_backend_algolia_tree_view">
         <field name="name">se.backend.algolia.tree (in connector_algolia)</field>

--- a/connector_search_engine/__manifest__.py
+++ b/connector_search_engine/__manifest__.py
@@ -17,6 +17,7 @@
     ],
     'data': [
         'views/se_backend.xml',
+        'views/se_index.xml',
         'views/se_menu.xml',
         'data/ir_cron.xml',
         'security/ir.model.access.csv',

--- a/connector_search_engine/components/adapter.py
+++ b/connector_search_engine/components/adapter.py
@@ -20,3 +20,6 @@ class SeAdapter(AbstractComponent):
 
     def delete(self, binding_ids):
         return NotImplemented
+
+    def clear(self):
+        return NotImplemented

--- a/connector_search_engine/components/adapter.py
+++ b/connector_search_engine/components/adapter.py
@@ -15,7 +15,7 @@ class SeAdapter(AbstractComponent):
     def match(cls, session, model):
         return True  # We are a generic exporter; how cool is that?
 
-    def add(self, datas):
+    def index(self, datas):
         return NotImplemented
 
     def delete(self, binding_ids):

--- a/connector_search_engine/components/exporter.py
+++ b/connector_search_engine/components/exporter.py
@@ -13,10 +13,10 @@ class SeExporter(Component):
     _base_mapper_usage = 'se.export.mapper'
     _base_backend_adapter_usage = 'se.backend.adapter'
 
-    def _add(self, data):
+    def _index(self, data):
         """ Index the record """
-        return self.backend_adapter.add(data)
+        return self.backend_adapter.index(data)
 
     def run(self):
         """ Run the synchronization """
-        return self._add([record.data for record in self.work.records])
+        return self._index([record.data for record in self.work.records])

--- a/connector_search_engine/components/exporter.py
+++ b/connector_search_engine/components/exporter.py
@@ -19,4 +19,5 @@ class SeExporter(Component):
 
     def run(self):
         """ Run the synchronization """
+        self.work.records.write({'sync_state': 'done'})
         return self._index([record.data for record in self.work.records])

--- a/connector_search_engine/components/exporter.py
+++ b/connector_search_engine/components/exporter.py
@@ -13,28 +13,10 @@ class SeExporter(Component):
     _base_mapper_usage = 'se.export.mapper'
     _base_backend_adapter_usage = 'se.backend.adapter'
 
-    def __init__(self, environment):
-        """
-        :param environment: current environment (backend, session, ...)
-        :type environment: :py:class:`connector.connector.Environment`
-        """
-        super(SeExporter, self).__init__(environment)
-        self.bindings = None
-
     def _add(self, data):
-        """ Create the SolR record """
+        """ Index the record """
         return self.backend_adapter.add(data)
 
-    def _export_data(self):
-        return NotImplemented
-
     def run(self):
-        """ Run the synchronization
-        :param binding_id: identifier of the binding record to export
-        """
-        datas = []
-        lang = self.work.index.lang_id.code
-        for record in self.work.records.with_context(lang=lang):
-            map_record = self.mapper.map_record(record)
-            datas.append(map_record.values())
-        return self._add(datas)
+        """ Run the synchronization """
+        return self._add([record.data for record in self.work.records])

--- a/connector_search_engine/data/ir_cron.xml
+++ b/connector_search_engine/data/ir_cron.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
-    <record forcecreate="True" id="ir_cron_export_all_index" model="ir.cron">
-        <field name="name">Export All index</field>
+    <record forcecreate="True" id="ir_cron_recompute_all_index" model="ir.cron">
+        <field name="name">Search engine: recompute all index</field>
         <field eval="True" name="active"/>
         <field name="user_id" ref="base.user_root"/>
         <field name="interval_number">1</field>
@@ -10,7 +10,20 @@
         <field name="numbercall">-1</field>
         <field eval="False" name="doall"/>
         <field eval="'se.index'" name="model"/>
-        <field eval="'export_all_index'" name="function"/>
+        <field eval="'recompute_all_index'" name="function"/>
+        <field eval="'()'" name="args"/>
+    </record>
+
+    <record forcecreate="True" id="ir_cron_export_binding" model="ir.cron">
+        <field name="name">Search engine: Generate job for exporting binding per index</field>
+        <field eval="True" name="active"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall"/>
+        <field eval="'se.index'" name="model"/>
+        <field eval="'generate_batch_export_per_index'" name="function"/>
         <field eval="'()'" name="args"/>
     </record>
 

--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -16,53 +16,31 @@ class SeBinding(models.AbstractModel):
         'se.index',
         string="Index",
         required=True)
-    sync_state = fields.Selection(
-        [('to_update', 'To update'),
-         ('scheduled', 'Scheduled'),
-         ('done', 'Done')],
-        default='to_update',
+    sync_state = fields.Selection([
+        ('new', 'New'),
+        ('to_update', 'To update'),
+        ('scheduled', 'Scheduled'),
+        ('done', 'Done'),
+        ],
+        default='new',
         readonly=True)
     date_modified = fields.Date(readonly=True)
     date_syncronized = fields.Date(readonly=True)
+    data = fields.Serialized()
 
-    @job(default_channel='root.search_engine')
     @api.model
-    def _scheduler_export(self, batch_size=5000, domain=None, delay=True):
-        if domain is None:
-            domain = []
-        domain.append(('sync_state', '=', 'to_update'))
-        records = self.search(domain)
-        if delay:
-            description = _('Prepare a batch export of indexes')
-            records = records.with_delay(description=description)
-        return records.export_batch(batch_size, delay=delay)
+    def create(self, vals):
+        record = super(SeBinding, self).create(vals)
+        record._jobify_recompute_json()
+        return record
 
-    @job(default_channel='root.search_engine')
-    @api.multi
-    def export_batch(self, batch_size=5000, delay=True):
-        datas = self.read_group(
-            [('id', 'in', self.ids)], ['index_id'], ['index_id'])
-        for data in datas:
-            bindings = self.search(data['__domain'])
-            bindings_count = len(bindings)
-            while bindings:
-                todo = processing = bindings[0:batch_size]
-                bindings = bindings[batch_size:]
-                if delay:
-                    description = _(
-                        "Export %d records of %d for index '%s'") % (
-                            len(processing),
-                            bindings_count,
-                            data['index_id'][1])
-                    todo = processing.with_delay(description=description)
-                todo.export()
-                processing.with_context(connector_no_export=True).write({
-                    'sync_state': 'scheduled',
-                })
+    def _jobify_recompute_json(self):
+        description = _('Recompute %s json and check if need update'
+                        % self._name)
+        for record in self:
+            record.with_delay(description=description).recompute_json()
 
-    @job(default_channel='root.search_engine')
-    @api.multi
-    def export(self):
+    def _work_by_index(self):
         for backend in self.mapped('se_backend_id'):
             for index in self.mapped('index_id'):
                 bindings = self.filtered(
@@ -72,5 +50,25 @@ class SeBinding(models.AbstractModel):
                 with specific_backend.work_on(
                     self._name, records=bindings, index=index
                 ) as work:
-                    exporter = work.component(usage='se.record.exporter')
-                    exporter.run()
+                    yield work
+
+    # TODO maybe we need to add lock (todo check)
+    @job(default_channel='root.search_engine.recompute')
+    def recompute_json(self):
+        for work in self._work_by_index():
+            mapper = work.component(usage='se.export.mapper')
+            lang = work.index.lang_id.code
+            for record in work.records.with_context(lang=lang):
+                data = mapper.map_record(record).values()
+                if record.data != data:
+                    vals = {'data': data}
+                    if record.sync_state in ('done', 'new'):
+                        vals['sync_state'] = 'to_update'
+                    record.write(vals)
+
+    @job(default_channel='root.search_engine')
+    @api.multi
+    def export(self):
+        for work in self._work_by_index():
+            exporter = work.component(usage='se.record.exporter')
+            exporter.run()

--- a/connector_search_engine/models/se_binding.py
+++ b/connector_search_engine/models/se_binding.py
@@ -54,7 +54,7 @@ class SeBinding(models.AbstractModel):
                     yield work
 
     # TODO maybe we need to add lock (todo check)
-    @job(default_channel='root.search_engine.recompute')
+    @job(default_channel='root.search_engine.recompute_json')
     def recompute_json(self, force_export=False):
         for work in self._work_by_index():
             mapper = work.component(usage='se.export.mapper')

--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -2,7 +2,8 @@
 # Copyright 2013 Akretion (http://www.akretion.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.addons.queue_job.job import job
 
 
 class SeIndex(models.Model):
@@ -26,6 +27,9 @@ class SeIndex(models.Model):
     exporter_id = fields.Many2one(
         'ir.exports',
         string='Exporter')
+    batch_size = fields.Integer(
+        default=5000,
+        help='Batch size for exporting element')
 
     _sql_constraints = [
         ('lang_model_uniq', 'unique(backend_id, lang_id, model_id)',
@@ -33,17 +37,46 @@ class SeIndex(models.Model):
     ]
 
     @api.model
-    def export_all_index(self, domain=None, delay=True):
+    def recompute_all_index(self, domain=None):
         if domain is None:
             domain = []
-        return self.search(domain).export_all(delay=delay)
+        return self.search(domain).recompute_all_binding()
 
-    @api.multi
-    def export_all(self, delay=True):
+    def recompute_all_binding(self):
         for record in self:
             binding_obj = self.env[record.model_id.model]
-            bindings = binding_obj.search([('index_id', '=', record.id)])
-            bindings.write({'sync_state': 'to_update'})
-            binding_obj._scheduler_export(
-                domain=[('index_id', '=', record.id)], delay=delay)
+            for bindings in binding_obj.search([('index_id', '=', record.id)]):
+                bindings._jobify_recompute_json()
+        return True
+
+    @api.model
+    def generate_batch_export_per_index(self, domain=None):
+        if domain is None:
+            domain = []
+        for record in self.search(domain):
+            description = _('Prepare a batch export of indexes')
+            record.with_delay(description=description).prepare_batch_export()
+        return True
+
+    def _get_domain_for_exporting_binding(self):
+        return [('index_id', '=', self.id), ('sync_state', '=', 'to_update')]
+
+    @job(default_channel='root.search_engine.prepare_batch_export')
+    def prepare_batch_export(self):
+        self.ensure_one()
+        domain = self._get_domain_for_exporting_binding()
+        bindings = self.env[self.model_id.model].search(domain)
+        bindings_count = len(bindings)
+        while bindings:
+            todo = processing = bindings[0:self.batch_size]
+            bindings = bindings[self.batch_size:]
+            description = _(
+                "Export %d records of %d for index '%s'") % (
+                    len(processing),
+                    bindings_count,
+                    self.name)
+            processing.with_delay(description=description).export()
+            processing.with_context(connector_no_export=True).write({
+                'sync_state': 'scheduled',
+            })
         return True

--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -36,39 +36,66 @@ class SeIndex(models.Model):
          'Lang and model of index must be uniq per backend.'),
     ]
 
+    def action_synchronize(self):
+        view = self.env.ref(
+            'connector_search_engine.se_index_synchronize_form_view')
+        return {
+            'name': _('Synchronize %s') % self.name,
+            'view_type': 'form',
+            'target': 'new',
+            'res_model': self._name,
+            'res_id': self.id,
+            'views': [(view.id, 'form')],
+            'type': 'ir.actions.act_window',
+            }
+
     @api.model
     def recompute_all_index(self, domain=None):
         if domain is None:
             domain = []
         return self.search(domain).recompute_all_binding()
 
-    def recompute_all_binding(self):
+    def force_recompute_all_binding(self):
+        return self.recompute_all_binding(force_export=True)
+
+    def recompute_all_binding(self, force_export=False):
         for record in self:
             binding_obj = self.env[record.model_id.model]
             for bindings in binding_obj.search([('index_id', '=', record.id)]):
-                bindings._jobify_recompute_json()
+                bindings._jobify_recompute_json(force_export=force_export)
         return True
+
+    def force_batch_export(self):
+        self.ensure_one()
+        bindings = self.env[self.model_id.model].search([
+            ('index_id', '=', self.id)])
+        bindings.write({'sync_state': 'to_update'})
+        self._jobify_batch_export()
+
+    def _jobify_batch_export(self):
+        self.ensure_one()
+        description = _("Prepare a batch export of index '%s'") % self.name
+        self.with_delay(description=description).batch_export()
 
     @api.model
     def generate_batch_export_per_index(self, domain=None):
         if domain is None:
             domain = []
         for record in self.search(domain):
-            description = _('Prepare a batch export of indexes')
-            record.with_delay(description=description).prepare_batch_export()
+            record._jobify_batch_export()
         return True
 
     def _get_domain_for_exporting_binding(self):
         return [('index_id', '=', self.id), ('sync_state', '=', 'to_update')]
 
     @job(default_channel='root.search_engine.prepare_batch_export')
-    def prepare_batch_export(self):
+    def batch_export(self):
         self.ensure_one()
         domain = self._get_domain_for_exporting_binding()
         bindings = self.env[self.model_id.model].search(domain)
         bindings_count = len(bindings)
         while bindings:
-            todo = processing = bindings[0:self.batch_size]
+            processing = bindings[0:self.batch_size]
             bindings = bindings[self.batch_size:]
             description = _(
                 "Export %d records of %d for index '%s'") % (
@@ -79,4 +106,12 @@ class SeIndex(models.Model):
             processing.with_context(connector_no_export=True).write({
                 'sync_state': 'scheduled',
             })
+        return True
+
+    def clear_index(self):
+        self.ensure_one()
+        backend = self.backend_id.specific_backend
+        with backend.work_on(self._name, index=self) as work:
+            adapter = work.component(usage='se.backend.adapter')
+            adapter.clear()
         return True

--- a/connector_search_engine/tests/__init__.py
+++ b/connector_search_engine/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import common

--- a/connector_search_engine/tests/common.py
+++ b/connector_search_engine/tests/common.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com)
+# Copyright 2018 ACSONE SA/NV
+# Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import mock
+from odoo import api, models
+from odoo.addons.component.tests.common import SavepointComponentCase
+
+
+class TestSeBackend(models.Model):
+    _name = 'test.se.backend'
+    _inherit = 'se.backend.spec.abstract'
+    _description = 'Unit Test SE Backend'
+
+    def init(self):
+        self.env['se.backend'].register_spec_backend(self)
+
+    def _register_hook(self):
+        self.env['se.backend'].register_spec_backend(self)
+
+
+class TestSeBackendCase(SavepointComponentCase):
+    """
+    Tests With a fake Se Backend
+    """
+
+    def _init_test_model(self, model_cls):
+        """
+        Function to init/create a new Odoo Model during unit test.
+        Based on base_kanban_stage/test/test_base_kanban_abstract.py
+        :param model_cls: Odoo Model class
+        :return: instance of model (empty)
+        """
+        registry = self.env.registry
+        registry.enter_test_mode()
+        cr = self.env.cr
+        model_cls._build_model(registry, cr)
+        model = self.env[model_cls._name].with_context(todo=[])
+        model._prepare_setup()
+        model._setup_base(partial=False)
+        model._setup_fields(partial=False)
+        model._setup_complete()
+        model._auto_init()
+        model.init()
+        model._auto_end()
+        return self.env[model_cls._name]
+
+    def setUp(self):
+        super(TestSeBackendCase, self).setUp()
+        # To load a new Model, we have to use a new cursor and env.
+        # Because there is a commit on the model._auto_init()
+        # Based on base_kanban_stage/test/test_base_kanban_abstract.py
+        # self.registry.enter_test_mode()
+        # self.old_cursor = self.cr
+        # self.cr = self.registry.cursor()
+        self.cr.commit = mock.MagicMock()
+        self.env = api.Environment(self.cr, self.uid, {})
+        self._init_test_model(TestSeBackend)
+        self.se_backend = self.env['test.se.backend'].create({
+            'specific_model': 'test.se.backend',
+        })
+
+    def tearDown(self):
+        self.registry.leave_test_mode()
+        super(TestSeBackendCase, self).tearDown()

--- a/connector_search_engine/views/se_backend.xml
+++ b/connector_search_engine/views/se_backend.xml
@@ -26,6 +26,7 @@
                                 <field name="lang_id"/>
                                 <field name="model_id"/>
                                 <field name="exporter_id"/>
+                                <field name="batch_size"/>
                                 <button name="export_all"
                                         icon="fa-refresh"
                                         type="object"/>

--- a/connector_search_engine/views/se_backend.xml
+++ b/connector_search_engine/views/se_backend.xml
@@ -27,7 +27,7 @@
                                 <field name="model_id"/>
                                 <field name="exporter_id"/>
                                 <field name="batch_size"/>
-                                <button name="export_all"
+                                <button name="action_synchronize"
                                         icon="fa-refresh"
                                         type="object"/>
                             </tree>
@@ -56,5 +56,6 @@
         <field name="domain">[]</field>
         <field name="context">{}</field>
     </record>
+
 
 </odoo>

--- a/connector_search_engine/views/se_index.xml
+++ b/connector_search_engine/views/se_index.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="se_index_synchronize_form_view">
+        <field name="name">se.backend.form (in connector_search_engine)</field>
+        <field name="model">se.backend</field>
+        <field name="arch" type="xml">
+            <form create="false" edit="false">
+                <sheet>
+                    <button
+                        name="force_recompute_all_binding"
+                        string="Recompute"
+                        type="object"
+                        class="oe_highlight"/>
+                    Force to recompute all binding of the index
+                    and set them to the state "To update"
+                    <separator/>
+                    <button
+                        name="force_batch_export"
+                        string="Export"
+                        type="object"
+                        class="oe_highlight"/>
+                    Force the export of all binding
+                    <separator/>
+                    <button
+                        name="clear_index"
+                        string="Clear"
+                        type="object"
+                        class="oe_highlight"/>
+                    Clear the index in the search engine
+                </sheet>
+                <footer>
+                    <button
+                        name="close"
+                        string="Close"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,3 +1,4 @@
 connector
 server-tools
-ak-incubator-base-jsonify https://github.com/akretion/ak-odoo-incubator 10-base_jsonify
+ak-incubator-base-jsonify https://github.com/akretion/ak-odoo-incubator 10.0
+queue https://github.com/akretion/queue 10.0-add-job-counter-for-test

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,4 +1,3 @@
 connector
 server-tools
 ak-incubator-base-jsonify https://github.com/akretion/ak-odoo-incubator 10.0
-queue https://github.com/akretion/queue 10.0-add-job-counter-for-test


### PR DESCRIPTION
One for computing the json (in multi worker)
One for reading and pushing the data.
The export is not more resilient (not blocked for one record that fail), faster because json can be computed in multi-worker

This PR depend on https://github.com/OCA/queue/pull/88