### PR TITLE
[FIX] domain on index model field

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -24,14 +24,13 @@ class SeIndex(models.Model):
 
     @api.model
     def _get_model_domain(self):
-        models = self.env['ir.model'].search([('transient', '=', False)])
-        se_model_ids = []
-        for model in models:
-            if model.model == 'se.binding':
+        se_model_names = []
+        for model in self.env:
+            if self.env[model]._abstract or self.env[model]._transient:
                 continue
-            if hasattr(self.env[model.model], '_se_model'):
-                se_model_ids.append(model.id)
-        return [('id', 'in', se_model_ids)]
+            if hasattr(self.env[model], '_se_model'):
+                se_model_names.append(model)
+        return [('model', 'in', se_model_names)]
 
     name = fields.Char(compute='_compute_name', store=True)
     backend_id = fields.Many2one(


### PR DESCRIPTION
The update of connector_search_engine was failing because it was looping on all database models even if there were not all in the registry yet, which was giving a key error.
So we loop only on what is already in the registry now. It should also be better in performance since we avoid querying the database.

@sebastienbeau 
@mourad-ehm FYI