### PR TITLE
[10.0][IMP] Improve index recompute (exceed cpu time limit if too much records)

### DIFF
--- a/connector_search_engine/models/se_index.py
+++ b/connector_search_engine/models/se_index.py
@@ -73,10 +73,14 @@ class SeIndex(models.Model):
         return self.recompute_all_binding(force_export=True)
 
     def recompute_all_binding(self, force_export=False):
-        for record in self:
-            binding_obj = self.env[record.model_id.model]
-            for binding in binding_obj.search([("index_id", "=", record.id)]):
-                binding._jobify_recompute_json(force_export=force_export)
+        target_models = self.mapped("model_id.model")
+        for target_model in target_models:
+            indexes = self.filtered(lambda r: r.model_id.model == target_model)
+            bindings = self.env[target_model].search(
+                [("index_id", "in", indexes.ids)]
+            )
+            if bindings:
+                bindings._jobify_recompute_json(force_export=force_export)
         return True
 
     @api.depends("lang_id", "model_id", "backend_id.name")


### PR DESCRIPTION
**Issue:**
In case of big database, recompute can take a long time and exceed the cpu time limit (from odoo config file).

**Fix:**
Improve the `recompute_all_binding(...)` by doing less `search`.

**Note:**
This job/cron create many children jobs. And job creation is quite expensive (about perf).
Maybe there is also an improvement to do into queue_job module.